### PR TITLE
[feature/youngtae-step2] Mini-Pay step2

### DIFF
--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -11,6 +11,7 @@ import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.SendToOthersResponseDto;
 import org.c4marathon.assignment.account.dto.response.SendToSavingAccountResponseDto;
 import org.c4marathon.assignment.account.service.AccountService;
+import org.c4marathon.assignment.account.service.BankingService;
 import org.c4marathon.assignment.user.domain.User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class AccountController {
 
 	private final AccountService accountService;
+	private final BankingService bankingService;
 
 	@PostMapping("/api/user/saving-account")
 	public ResponseEntity<SavingAccountResponseDto> generateSavingAccount(
@@ -70,7 +72,7 @@ public class AccountController {
 		@AuthenticationPrincipal User user,
 		@Valid @RequestBody SendToOthersRequestDto requestDto
 	) {
-		SendToOthersResponseDto sendToOthersResponseDto = accountService.sendToOthers(
+		SendToOthersResponseDto sendToOthersResponseDto = bankingService.sendToOthers(
 			othersAccountId,
 			user,
 			requestDto

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -3,8 +3,8 @@ package org.c4marathon.assignment.account.controller;
 import java.util.List;
 
 import org.c4marathon.assignment.account.dto.request.ChargeRequestDto;
-import org.c4marathon.assignment.account.dto.request.SendRequestDto;
 import org.c4marathon.assignment.account.dto.request.SendToOthersRequestDto;
+import org.c4marathon.assignment.account.dto.request.SendToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
@@ -48,7 +48,7 @@ public class AccountController {
 	@PostMapping("/api/send")
 	public ResponseEntity<SendResponseDto> sendMoney(
 		@AuthenticationPrincipal User user,
-		@Valid @RequestBody SendRequestDto requestDto
+		@Valid @RequestBody SendToSavingAccountRequestDto requestDto
 	) {
 		SendResponseDto sendResponseDto = accountService.sendMoney(user, requestDto);
 		return ResponseEntity.ok(sendResponseDto);

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -8,8 +8,8 @@ import org.c4marathon.assignment.account.dto.request.SendToSavingAccountRequestD
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
-import org.c4marathon.assignment.account.dto.response.SendResponseDto;
 import org.c4marathon.assignment.account.dto.response.SendToOthersResponseDto;
+import org.c4marathon.assignment.account.dto.response.SendToSavingAccountResponseDto;
 import org.c4marathon.assignment.account.service.AccountService;
 import org.c4marathon.assignment.user.domain.User;
 import org.springframework.http.ResponseEntity;
@@ -46,12 +46,12 @@ public class AccountController {
 	}
 
 	@PostMapping("/api/send")
-	public ResponseEntity<SendResponseDto> sendMoney(
+	public ResponseEntity<SendToSavingAccountResponseDto> sendMoney(
 		@AuthenticationPrincipal User user,
 		@Valid @RequestBody SendToSavingAccountRequestDto requestDto
 	) {
-		SendResponseDto sendResponseDto = accountService.sendMoney(user, requestDto);
-		return ResponseEntity.ok(sendResponseDto);
+		SendToSavingAccountResponseDto sendToSavingAccountResponseDto = accountService.sendMoney(user, requestDto);
+		return ResponseEntity.ok(sendToSavingAccountResponseDto);
 	}
 
 	@PostMapping("/api/account/charge")

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -63,16 +63,14 @@ public class AccountController {
 		return ResponseEntity.ok(chargeResponseDto);
 	}
 
-	@PostMapping("/api/send/{othersAccountId}/{othersAccountType}")
+	@PostMapping("/api/send/{othersAccountId}")
 	public ResponseEntity<SendToOthersResponseDto> sendToOthers(
 		@PathVariable("othersAccountId") Long othersAccountId,
-		@PathVariable("othersAccountType") String othersAccountType,
 		@AuthenticationPrincipal User user,
 		@Valid @RequestBody SendToOthersRequestDto requestDto
 	) {
 		SendToOthersResponseDto sendToOthersResponseDto = accountService.sendToOthers(
 			othersAccountId,
-			othersAccountType,
 			user,
 			requestDto
 		);

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -48,8 +48,8 @@ public class AccountController {
 	@PostMapping("/api/send")
 	public ResponseEntity<SendResponseDto> sendMoney(
 		@AuthenticationPrincipal User user,
-		@Valid @RequestBody SendRequestDto requestDto) {
-
+		@Valid @RequestBody SendRequestDto requestDto
+	) {
 		SendResponseDto sendResponseDto = accountService.sendMoney(user, requestDto);
 		return ResponseEntity.ok(sendResponseDto);
 	}
@@ -57,8 +57,8 @@ public class AccountController {
 	@PostMapping("/api/account/charge")
 	public ResponseEntity<ChargeResponseDto> chargeMainAccount(
 		@AuthenticationPrincipal User user,
-		@Valid @RequestBody ChargeRequestDto requestDto) {
-
+		@Valid @RequestBody ChargeRequestDto requestDto
+	) {
 		ChargeResponseDto chargeResponseDto = accountService.chargeMainAccount(user, requestDto);
 		return ResponseEntity.ok(chargeResponseDto);
 	}

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -45,12 +45,13 @@ public class AccountController {
 		return ResponseEntity.ok(accountResponseDto);
 	}
 
-	@PostMapping("/api/send")
-	public ResponseEntity<SendToSavingAccountResponseDto> sendMoney(
+	@PostMapping("/api/send-saving")
+	public ResponseEntity<SendToSavingAccountResponseDto> sendToSavingAccount(
 		@AuthenticationPrincipal User user,
 		@Valid @RequestBody SendToSavingAccountRequestDto requestDto
 	) {
-		SendToSavingAccountResponseDto sendToSavingAccountResponseDto = accountService.sendMoney(user, requestDto);
+		SendToSavingAccountResponseDto sendToSavingAccountResponseDto = accountService.sendToSavingAccount(user,
+			requestDto);
 		return ResponseEntity.ok(sendToSavingAccountResponseDto);
 	}
 

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -4,15 +4,18 @@ import java.util.List;
 
 import org.c4marathon.assignment.account.dto.request.ChargeRequestDto;
 import org.c4marathon.assignment.account.dto.request.SendRequestDto;
+import org.c4marathon.assignment.account.dto.request.SendToOthersRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.SendResponseDto;
+import org.c4marathon.assignment.account.dto.response.SendToOthersResponseDto;
 import org.c4marathon.assignment.account.service.AccountService;
 import org.c4marathon.assignment.user.domain.User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -60,4 +63,19 @@ public class AccountController {
 		return ResponseEntity.ok(chargeResponseDto);
 	}
 
+	@PostMapping("/api/send/{othersAccountId}/{othersAccountType}")
+	public ResponseEntity<SendToOthersResponseDto> sendToOthers(
+		@PathVariable("othersAccountId") Long othersAccountId,
+		@PathVariable("othersAccountType") String othersAccountType,
+		@AuthenticationPrincipal User user,
+		@Valid @RequestBody SendToOthersRequestDto requestDto
+	) {
+		SendToOthersResponseDto sendToOthersResponseDto = accountService.sendToOthers(
+			othersAccountId,
+			othersAccountType,
+			user,
+			requestDto
+		);
+		return ResponseEntity.ok(sendToOthersResponseDto);
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/account/domain/Account.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/Account.java
@@ -60,11 +60,13 @@ public class Account {
 		this.user = user;
 	}
 
-	public void decreaseAmount(int amount) {
+	public int decreaseAmount(int amount) {
 		if (this.amount < amount) {
 			throw new BaseException(AccountErrorCode.NOT_ENOUGH_AMOUNT);
 		}
 		this.amount -= amount;
+
+		return amount;
 	}
 
 	public void increaseAmount(int amount) {

--- a/src/main/java/org/c4marathon/assignment/account/dto/AccountMapper.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/AccountMapper.java
@@ -8,6 +8,8 @@ import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.SendResponseDto;
+import org.c4marathon.assignment.account.dto.response.SendToOthersResponseDto;
+import org.c4marathon.assignment.user.domain.User;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -55,6 +57,13 @@ public class AccountMapper {
 			findAccount.getId(),
 			findAccount.getAmount(),
 			findAccount.getLimitAmount()
+		);
+	}
+
+	public static SendToOthersResponseDto sendToOthersResponseDto(User user, int sentAmount) {
+		return new SendToOthersResponseDto(
+			user.getName(),
+			sentAmount
 		);
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/AccountMapper.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/AccountMapper.java
@@ -7,8 +7,8 @@ import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
-import org.c4marathon.assignment.account.dto.response.SendResponseDto;
 import org.c4marathon.assignment.account.dto.response.SendToOthersResponseDto;
+import org.c4marathon.assignment.account.dto.response.SendToSavingAccountResponseDto;
 import org.c4marathon.assignment.user.domain.User;
 
 import lombok.AccessLevel;
@@ -32,8 +32,8 @@ public class AccountMapper {
 			.collect(Collectors.toList());
 	}
 
-	public static SendResponseDto toSendResponseDto(Account toAccount, Account fromAccount) {
-		return new SendResponseDto(
+	public static SendToSavingAccountResponseDto toSendResponseDto(Account toAccount, Account fromAccount) {
+		return new SendToSavingAccountResponseDto(
 			toAccount.getId(),
 			toAccount.getType().getType(),
 			toAccount.getAmount(),

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/SendToOthersRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/SendToOthersRequestDto.java
@@ -1,8 +1,15 @@
 package org.c4marathon.assignment.account.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record SendToOthersRequestDto(
+	@NotNull(message = "계좌번호는 필수 입력 항목입니다.")
 	Long accountId,
+	@NotBlank(message = "계좌 타입는 필수 입력 항목입니다.")
 	String accountType,
+	@Min(value = 0, message = "송금금액은 0원 이상이어야 합니다.")
 	int sendAmount
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/SendToOthersRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/SendToOthersRequestDto.java
@@ -1,15 +1,12 @@
 package org.c4marathon.assignment.account.dto.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record SendToOthersRequestDto(
 	@NotNull(message = "계좌번호는 필수 입력 항목입니다.")
 	Long accountId,
-	@NotBlank(message = "계좌 타입는 필수 입력 항목입니다.")
-	String accountType,
 	@Min(value = 0, message = "송금금액은 0원 이상이어야 합니다.")
-	int sendAmount
+	int remittanceAmount
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/SendToOthersRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/SendToOthersRequestDto.java
@@ -1,0 +1,8 @@
+package org.c4marathon.assignment.account.dto.request;
+
+public record SendToOthersRequestDto(
+	Long accountId,
+	String accountType,
+	int sendAmount
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/SendToSavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/SendToSavingAccountRequestDto.java
@@ -1,20 +1,14 @@
 package org.c4marathon.assignment.account.dto.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record SendToSavingAccountRequestDto(
 	@NotNull(message = "계좌번호는 필수 입력 항목입니다.")
 	Long toAccountId,
-	@NotBlank(message = "계좌 타입는 필수 입력 항목입니다.")
-	String toAccountType,
 	@Min(value = 0, message = "송금금액은 0원 이상이어야 합니다.")
 	int sendToMoney,
 	@NotNull(message = "계좌번호는 필수 입력 항목입니다.")
-	Long fromAccountId,
-	@NotBlank(message = "계좌 타입는 필수 입력 항목입니다.")
-	String fromAccountType
-
+	Long fromAccountId
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/SendToSavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/SendToSavingAccountRequestDto.java
@@ -7,7 +7,7 @@ public record SendToSavingAccountRequestDto(
 	@NotNull(message = "계좌번호는 필수 입력 항목입니다.")
 	Long toAccountId,
 	@Min(value = 0, message = "송금금액은 0원 이상이어야 합니다.")
-	int sendToMoney,
+	int remittanceMoney,
 	@NotNull(message = "계좌번호는 필수 입력 항목입니다.")
 	Long fromAccountId
 ) {

--- a/src/main/java/org/c4marathon/assignment/account/dto/request/SendToSavingAccountRequestDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/request/SendToSavingAccountRequestDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record SendRequestDto(
+public record SendToSavingAccountRequestDto(
 	@NotNull(message = "계좌번호는 필수 입력 항목입니다.")
 	Long toAccountId,
 	@NotBlank(message = "계좌 타입는 필수 입력 항목입니다.")

--- a/src/main/java/org/c4marathon/assignment/account/dto/response/ChargeResponseDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/response/ChargeResponseDto.java
@@ -2,7 +2,7 @@ package org.c4marathon.assignment.account.dto.response;
 
 public record ChargeResponseDto(
 	Long accountId,
-	int amount,
+	int chargedAmount,
 	int limitAmount
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/response/SendToOthersResponseDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/response/SendToOthersResponseDto.java
@@ -3,6 +3,6 @@ package org.c4marathon.assignment.account.dto.response;
 public record SendToOthersResponseDto(
 
 	String sendFromUserName,
-	int amount
+	int remittanceAmount
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/account/dto/response/SendToOthersResponseDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/response/SendToOthersResponseDto.java
@@ -1,0 +1,8 @@
+package org.c4marathon.assignment.account.dto.response;
+
+public record SendToOthersResponseDto(
+
+	String sendFromUserName,
+	int amount
+) {
+}

--- a/src/main/java/org/c4marathon/assignment/account/dto/response/SendToSavingAccountResponseDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/response/SendToSavingAccountResponseDto.java
@@ -1,6 +1,6 @@
 package org.c4marathon.assignment.account.dto.response;
 
-public record SendResponseDto(
+public record SendToSavingAccountResponseDto(
 	Long toAccountId,
 	String toAccountType,
 	int toAccountMoney,

--- a/src/main/java/org/c4marathon/assignment/account/exception/AccountErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/account/exception/AccountErrorCode.java
@@ -16,8 +16,8 @@ public enum AccountErrorCode implements ErrorCode {
 	NOT_ENOUGH_CHARGE_AMOUNT("충전 한도를 초과했습니다.", "ACCOUNT_005"),
 	NOT_ACCESS_CHARGE("계좌 금액 충전에 접근할 수 없는 계좌입니다.", "ACCOUNT_006"),
 	FAILED_ACCOUNT_DEPOSIT("해당 계좌에 입금을 실패했습니다.", "ACCOUNT_007"),
-	NOT_MAIN_ACCOUNT("메인 계좌가 아닙니다.", "ACCOUNT_008");
-
+	NOT_MAIN_ACCOUNT("메인 계좌가 아닙니다.", "ACCOUNT_008"),
+	FAILED_AUTO_CHARGING("부족한 금액 충전을 실패했습니다.", "ACCOUNT_009");
 	private final String message;
 	private final String code;
 }

--- a/src/main/java/org/c4marathon/assignment/account/exception/AccountErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/account/exception/AccountErrorCode.java
@@ -15,7 +15,8 @@ public enum AccountErrorCode implements ErrorCode {
 	NOT_AUTHORIZED_ACCOUNT("계좌 인출 권한이 없습니다.", "ACCOUNT_004"),
 	NOT_ENOUGH_CHARGE_AMOUNT("충전 한도를 초과했습니다.", "ACCOUNT_005"),
 	NOT_ACCESS_CHARGE("계좌 금액 충전에 접근할 수 없는 계좌입니다.", "ACCOUNT_006"),
-	FAILED_ACCOUNT_DEPOSIT("해당 계좌에 입금을 실패했습니다.", "ACCOUNT_007");
+	FAILED_ACCOUNT_DEPOSIT("해당 계좌에 입금을 실패했습니다.", "ACCOUNT_007"),
+	NOT_MAIN_ACCOUNT("메인 계좌가 아닙니다.", "ACCOUNT_008");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/org/c4marathon/assignment/account/exception/AccountErrorCode.java
+++ b/src/main/java/org/c4marathon/assignment/account/exception/AccountErrorCode.java
@@ -14,7 +14,8 @@ public enum AccountErrorCode implements ErrorCode {
 	NOT_ENOUGH_AMOUNT("계좌 금액이 충분하지 않습니다.", "ACCOUNT_003"),
 	NOT_AUTHORIZED_ACCOUNT("계좌 인출 권한이 없습니다.", "ACCOUNT_004"),
 	NOT_ENOUGH_CHARGE_AMOUNT("충전 한도를 초과했습니다.", "ACCOUNT_005"),
-	NOT_ACCESS_CHARGE("계좌 금액 충전에 접근할 수 없는 계좌입니다.", "ACCOUNT_006");
+	NOT_ACCESS_CHARGE("계좌 금액 충전에 접근할 수 없는 계좌입니다.", "ACCOUNT_006"),
+	FAILED_ACCOUNT_DEPOSIT("해당 계좌에 입금을 실패했습니다.", "ACCOUNT_007");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.c4marathon.assignment.account.domain.Account;
-import org.c4marathon.assignment.account.domain.AccountType;
 import org.c4marathon.assignment.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,9 +14,6 @@ import org.springframework.stereotype.Repository;
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
 	List<Account> findAllByUser(User user);
-
-	@Query("SELECT a FROM Account a JOIN FETCH a.user WHERE a.id = :id AND a.type = :type")
-	Optional<Account> findByIdAndType(@Param("id") Long accountId, @Param("type") AccountType findAccountType);
 
 	@Query("SELECT a FROM Account a JOIN FETCH a.user WHERE a.id = :id")
 	Optional<Account> findById(@Param("id") Long accountId);

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -1,11 +1,12 @@
 package org.c4marathon.assignment.account.repository;
 
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
-
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,8 +14,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
-	List<Account> findAllByUser(User user);
+    List<Account> findAllByUser(User user);
 
-	@Query("SELECT a FROM Account a JOIN FETCH a.user WHERE a.id = :id")
-	Optional<Account> findById(@Param("id") Long accountId);
+    @Query("SELECT a FROM Account a JOIN FETCH a.user WHERE a.id = :id")
+    Optional<Account> findById(@Param("id") Long accountId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM Account a JOIN FETCH a.user WHERE a.id = :id")
+    Optional<Account> findByIdWithLock(@Param("id") Long accountId);
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -61,8 +61,8 @@ public class AccountService {
 	public SendResponseDto sendMoney(User user, SendToSavingAccountRequestDto sendToSavingAccountRequestDto) {
 		int sendToMoney = sendToSavingAccountRequestDto.sendToMoney();
 
-		Account toAccount = findAccount(sendToSavingAccountRequestDto.toAccountId());
-		Account fromAccount = findAccount(sendToSavingAccountRequestDto.fromAccountId());
+		Account toAccount = getAccount(sendToSavingAccountRequestDto.toAccountId());
+		Account fromAccount = getAccount(sendToSavingAccountRequestDto.fromAccountId());
 
 		if (!verifyAccountByUser(user, toAccount) || !verifyAccountByUser(user, fromAccount)) {
 			throw new BaseException(AccountErrorCode.NOT_AUTHORIZED_ACCOUNT);
@@ -74,7 +74,7 @@ public class AccountService {
 		return AccountMapper.toSendResponseDto(toAccount, fromAccount);
 	}
 
-	private Account findAccount(Long accountId) {
+	private Account getAccount(Long accountId) {
 
 		return accountRepository.findById(accountId)
 			.orElseThrow(() -> new BaseException(AccountErrorCode.NOT_FOUND_ACCOUNT));
@@ -126,7 +126,7 @@ public class AccountService {
 
 	@Transactional(isolation = Isolation.REPEATABLE_READ)
 	public int withdrawal(User user, SendToOthersRequestDto requestDto) {
-		Account userAccount = findAccount(requestDto.accountId());
+		Account userAccount = getAccount(requestDto.accountId());
 
 		if (!verifyAccountByUser(user, userAccount)) {
 			throw new BaseException(AccountErrorCode.NOT_AUTHORIZED_ACCOUNT);
@@ -146,7 +146,7 @@ public class AccountService {
 		SendToOthersRequestDto requestDto
 	) {
 		try {
-			Account othersAccount = findAccount(othersAccountId);
+			Account othersAccount = getAccount(othersAccountId);
 
 			if (!verifyMainAccount(othersAccount)) {
 				throw new BaseException(AccountErrorCode.NOT_MAIN_ACCOUNT);
@@ -156,7 +156,7 @@ public class AccountService {
 
 			return AccountMapper.sendToOthersResponseDto(othersAccount.getUser(), sendToMoney);
 		} catch (Exception e) {
-			Account userAccount = findAccount(requestDto.accountId());
+			Account userAccount = getAccount(requestDto.accountId());
 			eventPublisher.publishEvent(new WithdrawalFailEvent(userAccount, requestDto.sendAmount()));
 			throw new BaseException(AccountErrorCode.FAILED_ACCOUNT_DEPOSIT);
 		}

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -132,6 +132,10 @@ public class AccountService {
 			throw new BaseException(AccountErrorCode.NOT_AUTHORIZED_ACCOUNT);
 		}
 
+		if (!verifyMainAccount(userAccount)) {
+			throw new BaseException(AccountErrorCode.NOT_ACCESS_CHARGE);
+		}
+
 		return userAccount.decreaseAmount(requestDto.sendAmount());
 	}
 

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -147,6 +147,11 @@ public class AccountService {
 	) {
 		try {
 			Account othersAccount = findAccount(othersAccountId, othersAccountType);
+
+			if (!verifyMainAccount(othersAccount)) {
+				throw new BaseException(AccountErrorCode.NOT_MAIN_ACCOUNT);
+			}
+
 			othersAccount.increaseAmount(sendToMoney);
 
 			return AccountMapper.sendToOthersResponseDto(othersAccount.getUser(), sendToMoney);

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -116,16 +116,7 @@ public class AccountService {
 		return Objects.equals(account.getType().getType(), MAIN_ACCOUNT.getType());
 	}
 
-	public SendToOthersResponseDto sendToOthers(
-		Long othersAccountId,
-		User user,
-		SendToOthersRequestDto requestDto
-	) {
-		int sendToMoney = withdrawal(user, requestDto);
-		return deposit(othersAccountId, sendToMoney, requestDto);
-	}
-
-	@Transactional(isolation = Isolation.REPEATABLE_READ)
+	@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = BaseException.class)
 	public int withdrawal(User user, SendToOthersRequestDto requestDto) {
 		Account userAccount = getAccount(requestDto.accountId());
 		int subAmount = userAccount.getAmount() - requestDto.remittanceAmount();
@@ -160,7 +151,7 @@ public class AccountService {
 		return (Math.abs(subAmount) + 9_999) / 10_000 * 10_000;
 	}
 
-	@Transactional(isolation = Isolation.REPEATABLE_READ)
+	@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = BaseException.class)
 	public SendToOthersResponseDto deposit(
 		Long othersAccountId,
 		int sendToMoney,

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -58,7 +58,7 @@ public class AccountService {
 	}
 
 	@Transactional(isolation = Isolation.SERIALIZABLE)
-	public SendToSavingAccountResponseDto sendMoney(User user,
+	public SendToSavingAccountResponseDto sendToSavingAccount(User user,
 		SendToSavingAccountRequestDto sendToSavingAccountRequestDto) {
 		int sendToMoney = sendToSavingAccountRequestDto.remittanceMoney();
 

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -85,7 +85,7 @@ public class AccountService {
 		return user.equals(account.getUser());
 	}
 
-	@Transactional(isolation = Isolation.SERIALIZABLE)
+	@Transactional(isolation = Isolation.REPEATABLE_READ)
 	public ChargeResponseDto chargeMainAccount(User user, ChargeRequestDto requestDto) {
 
 		Account findAccount = accountRepository.findById(requestDto.accountId())

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -11,8 +11,8 @@ import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.AccountType;
 import org.c4marathon.assignment.account.dto.AccountMapper;
 import org.c4marathon.assignment.account.dto.request.ChargeRequestDto;
-import org.c4marathon.assignment.account.dto.request.SendRequestDto;
 import org.c4marathon.assignment.account.dto.request.SendToOthersRequestDto;
+import org.c4marathon.assignment.account.dto.request.SendToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
@@ -59,11 +59,13 @@ public class AccountService {
 	}
 
 	@Transactional(isolation = Isolation.SERIALIZABLE)
-	public SendResponseDto sendMoney(User user, SendRequestDto sendRequestDto) {
-		int sendToMoney = sendRequestDto.sendToMoney();
+	public SendResponseDto sendMoney(User user, SendToSavingAccountRequestDto sendToSavingAccountRequestDto) {
+		int sendToMoney = sendToSavingAccountRequestDto.sendToMoney();
 
-		Account toAccount = findAccount(sendRequestDto.toAccountId(), sendRequestDto.toAccountType());
-		Account fromAccount = findAccount(sendRequestDto.fromAccountId(), sendRequestDto.fromAccountType());
+		Account toAccount = findAccount(sendToSavingAccountRequestDto.toAccountId(),
+			sendToSavingAccountRequestDto.toAccountType());
+		Account fromAccount = findAccount(sendToSavingAccountRequestDto.fromAccountId(),
+			sendToSavingAccountRequestDto.fromAccountType());
 
 		if (!verifyAccountByUser(user, toAccount) || !verifyAccountByUser(user, fromAccount)) {
 			throw new BaseException(AccountErrorCode.NOT_AUTHORIZED_ACCOUNT);

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -15,8 +15,8 @@ import org.c4marathon.assignment.account.dto.request.SendToSavingAccountRequestD
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
-import org.c4marathon.assignment.account.dto.response.SendResponseDto;
 import org.c4marathon.assignment.account.dto.response.SendToOthersResponseDto;
+import org.c4marathon.assignment.account.dto.response.SendToSavingAccountResponseDto;
 import org.c4marathon.assignment.account.exception.AccountErrorCode;
 import org.c4marathon.assignment.account.repository.AccountRepository;
 import org.c4marathon.assignment.common.exception.runtime.BaseException;
@@ -58,8 +58,9 @@ public class AccountService {
 	}
 
 	@Transactional(isolation = Isolation.SERIALIZABLE)
-	public SendResponseDto sendMoney(User user, SendToSavingAccountRequestDto sendToSavingAccountRequestDto) {
-		int sendToMoney = sendToSavingAccountRequestDto.sendToMoney();
+	public SendToSavingAccountResponseDto sendMoney(User user,
+		SendToSavingAccountRequestDto sendToSavingAccountRequestDto) {
+		int sendToMoney = sendToSavingAccountRequestDto.remittanceMoney();
 
 		Account toAccount = getAccount(sendToSavingAccountRequestDto.toAccountId());
 		Account fromAccount = getAccount(sendToSavingAccountRequestDto.fromAccountId());
@@ -136,7 +137,7 @@ public class AccountService {
 			throw new BaseException(AccountErrorCode.NOT_ACCESS_CHARGE);
 		}
 
-		return userAccount.decreaseAmount(requestDto.sendAmount());
+		return userAccount.decreaseAmount(requestDto.remittanceAmount());
 	}
 
 	@Transactional(isolation = Isolation.REPEATABLE_READ)
@@ -157,7 +158,7 @@ public class AccountService {
 			return AccountMapper.sendToOthersResponseDto(othersAccount.getUser(), sendToMoney);
 		} catch (Exception e) {
 			Account userAccount = getAccount(requestDto.accountId());
-			eventPublisher.publishEvent(new WithdrawalFailEvent(userAccount, requestDto.sendAmount()));
+			eventPublisher.publishEvent(new WithdrawalFailEvent(userAccount, requestDto.remittanceAmount()));
 			throw new BaseException(AccountErrorCode.FAILED_ACCOUNT_DEPOSIT);
 		}
 	}

--- a/src/main/java/org/c4marathon/assignment/account/service/BankingService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/BankingService.java
@@ -1,0 +1,24 @@
+package org.c4marathon.assignment.account.service;
+
+import org.c4marathon.assignment.account.dto.request.SendToOthersRequestDto;
+import org.c4marathon.assignment.account.dto.response.SendToOthersResponseDto;
+import org.c4marathon.assignment.user.domain.User;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BankingService {
+
+	private final AccountService accountService;
+
+	public SendToOthersResponseDto sendToOthers(
+		Long othersAccountId,
+		User user,
+		SendToOthersRequestDto requestDto
+	) {
+		int sendToMoney = accountService.withdrawal(user, requestDto);
+		return accountService.deposit(othersAccountId, sendToMoney, requestDto);
+	}
+}

--- a/src/main/java/org/c4marathon/assignment/event/account/AccountEventHandler.java
+++ b/src/main/java/org/c4marathon/assignment/event/account/AccountEventHandler.java
@@ -40,5 +40,6 @@ public class AccountEventHandler {
 	public void cancelWithdrawal(WithdrawalFailEvent event) {
 		Account withdrawnAccount = event.getAccount();
 		withdrawnAccount.increaseAmount(event.getWithdrawnAmount());
+		// 비동기 시 UI 변경 등 여러가지 고려 및 변경해야될 사안들이 많아짐
 	}
 }

--- a/src/main/java/org/c4marathon/assignment/event/account/AccountEventHandler.java
+++ b/src/main/java/org/c4marathon/assignment/event/account/AccountEventHandler.java
@@ -34,4 +34,11 @@ public class AccountEventHandler {
 
 		log.info("{} 회원 메인 계좌 생성 완료", event.getUser().getName());
 	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void cancelWithdrawal(WithdrawalFailEvent event) {
+		Account withdrawnAccount = event.getAccount();
+		withdrawnAccount.increaseAmount(event.getWithdrawnAmount());
+	}
 }

--- a/src/main/java/org/c4marathon/assignment/event/account/WithdrawalFailEvent.java
+++ b/src/main/java/org/c4marathon/assignment/event/account/WithdrawalFailEvent.java
@@ -1,0 +1,17 @@
+package org.c4marathon.assignment.event.account;
+
+import org.c4marathon.assignment.account.domain.Account;
+
+import lombok.Getter;
+
+@Getter
+public class WithdrawalFailEvent {
+
+	private Account account;
+	private int withdrawnAmount;
+
+	public WithdrawalFailEvent(Account account, int withdrawnAmount) {
+		this.account = account;
+		this.withdrawnAmount = withdrawnAmount;
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
@@ -117,7 +117,7 @@ class AccountControllerTest extends ApiTestSupport {
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.accountId").value(mainAccount.getId()))
-			.andExpect(jsonPath("$.amount").value(mainAccount.getAmount() + 300_000))
+			.andExpect(jsonPath("$.chargedAmount").value(mainAccount.getAmount() + 300_000))
 			.andExpect(jsonPath("$.limitAmount").value(mainAccount.getLimitAmount() - 300_000)
 			);
 	}
@@ -137,7 +137,6 @@ class AccountControllerTest extends ApiTestSupport {
 
 		SendToOthersRequestDto requestDto = new SendToOthersRequestDto(
 			mainAccount1.getId(),
-			MAIN_ACCOUNT.getType(),
 			sendToAmount
 		);
 
@@ -150,7 +149,7 @@ class AccountControllerTest extends ApiTestSupport {
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.sendFromUserName").value(others.getName()))
-			.andExpect(jsonPath("$.amount").value(sendToAmount)
+			.andExpect(jsonPath("$.remittanceAmount").value(sendToAmount)
 			);
 	}
 }

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
@@ -10,8 +10,8 @@ import java.util.List;
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.AccountType;
 import org.c4marathon.assignment.account.dto.request.ChargeRequestDto;
-import org.c4marathon.assignment.account.dto.request.SendRequestDto;
 import org.c4marathon.assignment.account.dto.request.SendToOthersRequestDto;
+import org.c4marathon.assignment.account.dto.request.SendToSavingAccountRequestDto;
 import org.c4marathon.assignment.common.fixture.AccountFixture;
 import org.c4marathon.assignment.common.fixture.UserFixture;
 import org.c4marathon.assignment.common.support.ApiTestSupport;
@@ -52,7 +52,7 @@ class AccountControllerTest extends ApiTestSupport {
 		Account savingAccount = AccountFixture.accountWithTypeAndAmount(loginUser, SAVING_ACCOUNT, 0);
 		accountRepository.saveAll(List.of(mainAccount, savingAccount));
 
-		SendRequestDto requestDto = new SendRequestDto(
+		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
 			mainAccount.getType().getType(),
 			300_000,

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
@@ -59,7 +59,7 @@ class AccountControllerTest extends ApiTestSupport {
 		);
 
 		// when		// then
-		mockMvc.perform(post("/api/send")
+		mockMvc.perform(post("/api/send-saving")
 				.header("Authorization", "Bearer " + token)
 				.content(toJson(requestDto))
 				.contentType(APPLICATION_JSON)

--- a/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/controller/AccountControllerTest.java
@@ -54,10 +54,8 @@ class AccountControllerTest extends ApiTestSupport {
 
 		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
-			mainAccount.getType().getType(),
 			300_000,
-			savingAccount.getId(),
-			savingAccount.getType().getType()
+			savingAccount.getId()
 		);
 
 		// when		// then
@@ -145,7 +143,7 @@ class AccountControllerTest extends ApiTestSupport {
 
 		// when		// then
 		mockMvc.perform(
-				post("/api/send/{othersAccountId}/{othersAccountType}", mainAccount2.getId(), MAIN_ACCOUNT.getType())
+				post("/api/send/{othersAccountId}", mainAccount2.getId())
 					.header("Authorization", "Bearer " + token)
 					.content(toJson(requestDto))
 					.contentType(APPLICATION_JSON)

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -76,15 +76,13 @@ class AccountServiceTest {
 
 		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
-			MAIN_ACCOUNT.getType(),
 			300_000,
-			savingAccount.getId(),
-			SAVING_ACCOUNT.getType()
+			savingAccount.getId()
 		);
 
-		given(accountRepository.findByIdAndType(mainAccount.getId(), MAIN_ACCOUNT)).willReturn(
+		given(accountRepository.findById(mainAccount.getId())).willReturn(
 			Optional.of(mainAccount));
-		given(accountRepository.findByIdAndType(savingAccount.getId(), SAVING_ACCOUNT)).willReturn(
+		given(accountRepository.findById(savingAccount.getId())).willReturn(
 			Optional.of(savingAccount));
 
 		// when
@@ -110,15 +108,13 @@ class AccountServiceTest {
 
 		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
-			MAIN_ACCOUNT.getType(),
 			300_000,
-			savingAccount.getId(),
-			SAVING_ACCOUNT.getType()
+			savingAccount.getId()
 		);
 
-		given(accountRepository.findByIdAndType(mainAccount.getId(), MAIN_ACCOUNT)).willReturn(
+		given(accountRepository.findById(mainAccount.getId())).willReturn(
 			Optional.of(mainAccount));
-		given(accountRepository.findByIdAndType(savingAccount.getId(), SAVING_ACCOUNT)).willReturn(
+		given(accountRepository.findById(savingAccount.getId())).willReturn(
 			Optional.of(savingAccount));
 
 		// when
@@ -140,15 +136,13 @@ class AccountServiceTest {
 
 		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
-			MAIN_ACCOUNT.getType(),
 			300_000,
-			savingAccount.getId(),
-			SAVING_ACCOUNT.getType()
+			savingAccount.getId()
 		);
 
-		given(accountRepository.findByIdAndType(mainAccount.getId(), MAIN_ACCOUNT)).willReturn(
+		given(accountRepository.findById(mainAccount.getId())).willReturn(
 			Optional.of(mainAccount));
-		given(accountRepository.findByIdAndType(savingAccount.getId(), SAVING_ACCOUNT)).willReturn(
+		given(accountRepository.findById(savingAccount.getId())).willReturn(
 			Optional.of(savingAccount));
 
 		// when
@@ -289,7 +283,7 @@ class AccountServiceTest {
 			100_000
 		);
 
-		given(accountRepository.findByIdAndType(mainAccount.getId(), MAIN_ACCOUNT))
+		given(accountRepository.findById(mainAccount.getId()))
 			.willReturn(Optional.of(mainAccount));
 
 		// when
@@ -311,11 +305,11 @@ class AccountServiceTest {
 			100_000
 		);
 
-		given(accountRepository.findByIdAndType(mainAccount.getId(), MAIN_ACCOUNT))
+		given(accountRepository.findById(mainAccount.getId()))
 			.willReturn(Optional.of(mainAccount));
 
 		// when
-		accountService.deposit(owner.getId(), MAIN_ACCOUNT.getType(), 200_000, requestDto);
+		accountService.deposit(owner.getId(), 200_000, requestDto);
 
 		// then
 		assertThat(mainAccount.getAmount()).isEqualTo(500_000);
@@ -333,12 +327,12 @@ class AccountServiceTest {
 			100_000
 		);
 
-		given(accountRepository.findByIdAndType(any(), any()))
+		given(accountRepository.findById(any()))
 			.willReturn(Optional.of(mainAccount));
 
 		// when
 		BaseException baseException = assertThrows(BaseException.class,
-			() -> accountService.deposit(owner.getId(), mainAccount.getType().getType(), 200_000, requestDto));
+			() -> accountService.deposit(owner.getId(), 200_000, requestDto));
 
 		// then
 		verify(eventPublisher).publishEvent(any(WithdrawalFailEvent.class));
@@ -365,13 +359,13 @@ class AccountServiceTest {
 			100_000
 		);
 
-		given(accountRepository.findByIdAndType(mainAccountByOwner.getId(), MAIN_ACCOUNT))
+		given(accountRepository.findById(mainAccountByOwner.getId()))
 			.willReturn(Optional.of(mainAccountByOwner));
-		given(accountRepository.findByIdAndType(mainAccountByOthers.getId(), MAIN_ACCOUNT))
+		given(accountRepository.findById(mainAccountByOthers.getId()))
 			.willReturn(Optional.of(mainAccountByOthers));
 
 		// when
-		accountService.sendToOthers(others.getId(), mainAccountByOthers.getType().getType(), owner, requestDto);
+		accountService.sendToOthers(others.getId(), owner, requestDto);
 
 		// then
 		assertAll(

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -15,7 +15,7 @@ import org.c4marathon.assignment.account.dto.request.SendToSavingAccountRequestD
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
-import org.c4marathon.assignment.account.dto.response.SendResponseDto;
+import org.c4marathon.assignment.account.dto.response.SendToSavingAccountResponseDto;
 import org.c4marathon.assignment.account.repository.AccountRepository;
 import org.c4marathon.assignment.common.exception.runtime.BaseException;
 import org.c4marathon.assignment.common.fixture.AccountFixture;
@@ -89,7 +89,7 @@ class AccountServiceTest {
 			Optional.of(savingAccount));
 
 		// when
-		SendResponseDto responseDto = accountService.sendMoney(owner, requestDto);
+		SendToSavingAccountResponseDto responseDto = accountService.sendMoney(owner, requestDto);
 
 		// then
 		assertAll(
@@ -173,7 +173,7 @@ class AccountServiceTest {
 		// then
 		assertAll(
 			() -> assertThat(responseDto.accountId()).isEqualTo(account.getId()),
-			() -> assertThat(responseDto.amount()).isEqualTo(600_000),
+			() -> assertThat(responseDto.chargedAmount()).isEqualTo(600_000),
 			() -> assertThat(responseDto.limitAmount()).isEqualTo(3_000_000 - requestDto.chargeAmount())
 		);
 	}
@@ -282,7 +282,6 @@ class AccountServiceTest {
 		Account mainAccount = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 300_000);
 		SendToOthersRequestDto requestDto = new SendToOthersRequestDto(
 			mainAccount.getId(),
-			MAIN_ACCOUNT.getType(),
 			100_000
 		);
 
@@ -304,7 +303,6 @@ class AccountServiceTest {
 		Account mainAccount = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 300_000);
 		SendToOthersRequestDto requestDto = new SendToOthersRequestDto(
 			mainAccount.getId(),
-			MAIN_ACCOUNT.getType(),
 			100_000
 		);
 
@@ -326,7 +324,6 @@ class AccountServiceTest {
 		Account mainAccount = AccountFixture.accountWithTypeAndAmount(owner, SAVING_ACCOUNT, 300_000);
 		SendToOthersRequestDto requestDto = new SendToOthersRequestDto(
 			mainAccount.getId(),
-			MAIN_ACCOUNT.getType(),
 			100_000
 		);
 
@@ -358,7 +355,6 @@ class AccountServiceTest {
 
 		SendToOthersRequestDto requestDto = new SendToOthersRequestDto(
 			mainAccountByOwner.getId(),
-			MAIN_ACCOUNT.getType(),
 			100_000
 		);
 

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -437,38 +437,4 @@ class AccountServiceTest {
 		verify(eventPublisher).publishEvent(any(WithdrawalFailEvent.class));
 		assertThat(baseException.getMessage()).isEqualTo("해당 계좌에 입금을 실패했습니다.");
 	}
-
-	@DisplayName("[요청자의 계좌에서 요청 금액만큼 출금하고 출금 금액을 상대방 메인 계좌에 입금한다.]")
-	@Test
-	void sendToOthers() {
-		// given
-		User owner = UserFixture.basicUser();
-		User others = UserFixture.basicUser();
-		ReflectionTestUtils.setField(owner, "id", 1L);
-		ReflectionTestUtils.setField(others, "id", 2L);
-
-		Account mainAccountByOwner = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 300_000);
-		Account mainAccountByOthers = AccountFixture.accountWithTypeAndAmount(others, MAIN_ACCOUNT, 100_000);
-		ReflectionTestUtils.setField(mainAccountByOwner, "id", 1L);
-		ReflectionTestUtils.setField(mainAccountByOthers, "id", 2L);
-
-		SendToOthersRequestDto requestDto = new SendToOthersRequestDto(
-			mainAccountByOwner.getId(),
-			100_000
-		);
-
-		given(accountRepository.findById(mainAccountByOwner.getId()))
-			.willReturn(Optional.of(mainAccountByOwner));
-		given(accountRepository.findById(mainAccountByOthers.getId()))
-			.willReturn(Optional.of(mainAccountByOthers));
-
-		// when
-		accountService.sendToOthers(others.getId(), owner, requestDto);
-
-		// then
-		assertAll(
-			() -> assertThat(mainAccountByOwner.getAmount()).isEqualTo(200_000),
-			() -> assertThat(mainAccountByOthers.getAmount()).isEqualTo(200_000)
-		);
-	}
 }

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.dto.request.ChargeRequestDto;
-import org.c4marathon.assignment.account.dto.request.SendRequestDto;
 import org.c4marathon.assignment.account.dto.request.SendToOthersRequestDto;
+import org.c4marathon.assignment.account.dto.request.SendToSavingAccountRequestDto;
 import org.c4marathon.assignment.account.dto.response.AccountResponseDto;
 import org.c4marathon.assignment.account.dto.response.ChargeResponseDto;
 import org.c4marathon.assignment.account.dto.response.SavingAccountResponseDto;
@@ -74,7 +74,7 @@ class AccountServiceTest {
 		Account mainAccount = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 600_000);
 		Account savingAccount = AccountFixture.accountWithTypeAndAmount(owner, SAVING_ACCOUNT, 0);
 
-		SendRequestDto requestDto = new SendRequestDto(
+		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
 			MAIN_ACCOUNT.getType(),
 			300_000,
@@ -108,7 +108,7 @@ class AccountServiceTest {
 		Account mainAccount = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 600_000);
 		Account savingAccount = AccountFixture.accountWithTypeAndAmount(owner, SAVING_ACCOUNT, 0);
 
-		SendRequestDto requestDto = new SendRequestDto(
+		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
 			MAIN_ACCOUNT.getType(),
 			300_000,
@@ -138,7 +138,7 @@ class AccountServiceTest {
 		Account mainAccount = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 200_000);
 		Account savingAccount = AccountFixture.accountWithTypeAndAmount(owner, SAVING_ACCOUNT, 0);
 
-		SendRequestDto requestDto = new SendRequestDto(
+		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
 			MAIN_ACCOUNT.getType(),
 			300_000,

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -91,7 +91,7 @@ class AccountServiceTest {
 			Optional.of(savingAccount));
 
 		// when
-		SendToSavingAccountResponseDto responseDto = accountService.sendMoney(owner, requestDto);
+		SendToSavingAccountResponseDto responseDto = accountService.sendToSavingAccount(owner, requestDto);
 
 		// then
 		assertAll(
@@ -124,7 +124,7 @@ class AccountServiceTest {
 
 		// when
 		BaseException baseException = assertThrows(
-			BaseException.class, () -> accountService.sendMoney(others, requestDto)
+			BaseException.class, () -> accountService.sendToSavingAccount(others, requestDto)
 		);
 
 		// then
@@ -152,7 +152,7 @@ class AccountServiceTest {
 
 		// when
 		BaseException baseException = assertThrows(BaseException.class,
-			() -> accountService.sendMoney(owner, requestDto));
+			() -> accountService.sendToSavingAccount(owner, requestDto));
 
 		// then
 		assertThat(baseException.getMessage()).isEqualTo("계좌 금액이 충분하지 않습니다.");

--- a/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/AccountServiceTest.java
@@ -74,6 +74,9 @@ class AccountServiceTest {
 		Account mainAccount = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 600_000);
 		Account savingAccount = AccountFixture.accountWithTypeAndAmount(owner, SAVING_ACCOUNT, 0);
 
+		ReflectionTestUtils.setField(mainAccount, "id", 1L);
+		ReflectionTestUtils.setField(savingAccount, "id", 2L);
+
 		SendToSavingAccountRequestDto requestDto = new SendToSavingAccountRequestDto(
 			mainAccount.getId(),
 			300_000,

--- a/src/test/java/org/c4marathon/assignment/account/service/BankingServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/BankingServiceTest.java
@@ -1,0 +1,72 @@
+package org.c4marathon.assignment.account.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.c4marathon.assignment.account.domain.AccountType.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.c4marathon.assignment.account.domain.Account;
+import org.c4marathon.assignment.account.dto.request.SendToOthersRequestDto;
+import org.c4marathon.assignment.account.repository.AccountRepository;
+import org.c4marathon.assignment.common.fixture.AccountFixture;
+import org.c4marathon.assignment.common.fixture.UserFixture;
+import org.c4marathon.assignment.user.domain.User;
+import org.c4marathon.assignment.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@SpringBootTest
+class BankingServiceTest {
+
+	@Autowired
+	private BankingService bankingService;
+
+	@Autowired
+	private AccountRepository accountRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PlatformTransactionManager transactionManager;
+
+	@AfterEach
+	void tearDown() {
+		accountRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@DisplayName("[요청자의 계좌에서 요청 금액만큼 출금하고 출금 금액을 상대방 메인 계좌에 입금한다.]")
+	@Test
+	void sendToOthers() {
+		// given
+		User owner = UserFixture.basicUser();
+		User others = UserFixture.others();
+		userRepository.saveAll(List.of(owner, others));
+
+		Account mainAccountByOwner = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 300_000);
+		Account mainAccountByOthers = AccountFixture.accountWithTypeAndAmount(others, MAIN_ACCOUNT, 100_000);
+		accountRepository.saveAll(List.of(mainAccountByOwner, mainAccountByOthers));
+
+		SendToOthersRequestDto requestDto = new SendToOthersRequestDto(
+			mainAccountByOwner.getId(),
+			100_000
+		);
+
+		// when
+		bankingService.sendToOthers(mainAccountByOthers.getId(), owner, requestDto);
+		Account updatedOwnerAccount = accountRepository.findById(mainAccountByOwner.getId()).orElseThrow();
+		Account updatedOthersAccount = accountRepository.findById(mainAccountByOthers.getId()).orElseThrow();
+
+		// then
+		assertAll(
+			() -> assertThat(updatedOwnerAccount.getAmount()).isEqualTo(200_000),
+			() -> assertThat(updatedOthersAccount.getAmount()).isEqualTo(200_000)
+		);
+	}
+}

--- a/src/test/java/org/c4marathon/assignment/account/service/TransactionalTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/service/TransactionalTest.java
@@ -1,0 +1,78 @@
+package org.c4marathon.assignment.account.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.c4marathon.assignment.account.domain.AccountType.MAIN_ACCOUNT;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.c4marathon.assignment.account.domain.Account;
+import org.c4marathon.assignment.account.dto.request.SendToOthersRequestDto;
+import org.c4marathon.assignment.account.repository.AccountRepository;
+import org.c4marathon.assignment.common.fixture.AccountFixture;
+import org.c4marathon.assignment.common.fixture.UserFixture;
+import org.c4marathon.assignment.user.domain.User;
+import org.c4marathon.assignment.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TransactionalTest {
+
+    @BeforeEach
+    void setUp() {
+        accountRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private AccountService accountService;
+
+    @DisplayName("")
+    @Test
+    void depositWithOneHundredWithPessimisticLock() throws InterruptedException {
+        // given
+        int threadCount = 10000;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        User owner = UserFixture.basicUser();
+        userRepository.save(owner);
+        Account mainAccount = AccountFixture.accountWithTypeAndAmount(owner, MAIN_ACCOUNT, 100_000);
+        Account savedAccount = accountRepository.save(mainAccount);
+        SendToOthersRequestDto requestDto = new SendToOthersRequestDto(
+                savedAccount.getId(),
+                100_000
+        );
+
+        long startTime = System.currentTimeMillis();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    accountService.deposit(mainAccount.getId(), 100_000, requestDto);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        long endTime = System.currentTimeMillis();
+        System.out.println("Execution time: " + (endTime - startTime) + " ms");
+        Account findAccount = accountRepository.findById(savedAccount.getId()).get();
+
+        // then
+        assertThat(findAccount.getAmount()).isEqualTo(1_000_100_000);
+    }
+}

--- a/src/test/java/org/c4marathon/assignment/common/fixture/UserFixture.java
+++ b/src/test/java/org/c4marathon/assignment/common/fixture/UserFixture.java
@@ -20,6 +20,15 @@ public class UserFixture {
 			.build();
 	}
 
+	public static User others() {
+		return User.builder()
+			.email("dasf@mini.com")
+			.name("김상대")
+			.password("mini1234")
+			.role(USER)
+			.build();
+	}
+
 	public static User userWithEncodingPassword(PasswordEncoder passwordEncoder) {
 		return User.builder()
 			.email("abc@mini.com")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a6cd89da-1b3d-4e2e-ab1d-271030aca419)


### 📑 작업 상세 내용
- 송금 전체 비즈니스 로직 처리 메서드에서 출금/입금 각각 로직을 호출하도록 설계
- 트랜잭션을 짧게 가져가고자 출금/입금 각각 다른 트랜잭션을 사용하도록 설계 
- 출금 후 입금 트랜잭션 실패 시 출금을 취소하는 이벤트 발행 및 처리 로직 추가

### 💫 작업 요약
- 유저 간 메인계좌 송금 로직 추가

### 🔍 중점적으로 리뷰 할 부분
- 잔액이 부족하다면 10,000원 단위로 충전 및 충전 한도가 있다는 요구사항은 잘 이해되지 않아 따로 구현하지 않았습니다.
- 한 번에 많은 인원들이 한 계좌에 송금한다던지 여러 가지 상황에 대한 고려는 아직 진행 중입니다.
- 출금과 입금 각각의 트랜잭션 격리 레벨을 `REPEATABLE_READ` 로 지정했습니다.
  - Phantom Read 문제를 막아주지 않지만, 입출금 각각 한 행(계좌)만 조회하기 떄문에 다른 행이 추가되어도 상관없다고 판단하였습니다.
    - MySQL을 사용하고 있는데 MySQL에서는 갭 락으로 인해 Phantom READ가 발생하지 않기도 하네요
  - 다만, 입/출금 모두 한 계좌에 두 개의 업데이트 트랜잭션이 생겼을 때 문제가 발생하네요. 이는 비관적 락을 사용하는 방법밖에 없나 고민이되네요