### PR TITLE
[feature/wonjun-step2] Mini-Pay step2

### DIFF
--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -48,9 +48,9 @@ public class AccountController {
 
 	// 적금 계좌 생성
 	@PostMapping("/account/create/{userId}")
-	public ResponseEntity<CommonResponse> CreateSavingsAccount(@PathVariable String userId,
+	public ResponseEntity<CommonResponse> CreateSavingsAccount(@PathVariable("userId") String userId,
 		@Valid @RequestBody SavingAccountPwDto savingAccountPwDto) {
-		boolean checkSaving = accountService.craeteSavingAccount(userId, savingAccountPwDto);
+		boolean checkSaving = accountService.createSavingAccount(userId, savingAccountPwDto);
 
 		if (checkSaving) {
 			CommonResponse res = new CommonResponse(

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -72,10 +72,33 @@ public class AccountController {
 	}
 
 	// 적금 계좌로 돈 송금
-	@PostMapping("/account/send/{userId}")
-	public ResponseEntity<CommonResponse> sendMoney(@PathVariable @RequestBody Long userId,
-		@Valid @RequestBody SendDto sendDto) {
-		boolean checkSend = accountService.sendSavingAccount(userId, sendDto);
+	@PostMapping("/account/send/saving")
+	public ResponseEntity<CommonResponse> sendMoney(@Valid @RequestBody SendDto sendDto) {
+		boolean checkSend = accountService.sendSavingAccount(sendDto);
+
+		if (checkSend) {
+			CommonResponse res = new CommonResponse(
+				200,
+				HttpStatus.OK,
+				"송금완료",
+				null
+			);
+			return new ResponseEntity<>(res, res.getHttpStatus());
+		} else {
+			CommonResponse res = new CommonResponse(
+				400,
+				HttpStatus.BAD_REQUEST,
+				"송금실패",
+				null
+			);
+			return new ResponseEntity<>(res, res.getHttpStatus());
+		}
+	}
+
+	// 다른 계좌로 돈 송금
+	@PostMapping("/account/send/other")
+	public ResponseEntity<CommonResponse> otherSendMoney(@Valid @RequestBody SendDto sendDto) {
+		boolean checkSend = accountService.sendOtherAccount(sendDto);
 
 		if (checkSend) {
 			CommonResponse res = new CommonResponse(

--- a/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
+++ b/src/main/java/org/c4marathon/assignment/account/controller/AccountController.java
@@ -52,10 +52,25 @@ public class AccountController {
 	}
 
 	// 적금 계좌로 돈 송금
-	@PostMapping("/account/send/{userId}")
-	public ResponseEntity<CommonResponse> sendMoney(@PathVariable("userId") @RequestBody String userId,
+	@PostMapping("/account/send/saving/{userId}")
+	public ResponseEntity<CommonResponse> sendMoneyToSaving(@PathVariable("userId") @RequestBody String userId,
 		@Valid @RequestBody SendDto sendDto) {
 		accountService.sendSavingAccount(userId, sendDto);
+
+		CommonResponse res = new CommonResponse(
+			200,
+			HttpStatus.OK,
+			"송금완료",
+			null
+		);
+		return new ResponseEntity<>(res, res.getHttpStatus());
+	}
+
+	// 다른 사람의 메인 계좌로 돈 송금
+	@PostMapping("/account/send/other/{userId}")
+	public ResponseEntity<CommonResponse> sendMoneyToOther(@PathVariable("userId") @RequestBody String userId,
+		@Valid @RequestBody SendDto sendDto) {
+		accountService.sendOtherAccount(userId, sendDto);
 
 		CommonResponse res = new CommonResponse(
 			200,

--- a/src/main/java/org/c4marathon/assignment/account/domain/Account.java
+++ b/src/main/java/org/c4marathon/assignment/account/domain/Account.java
@@ -30,7 +30,7 @@ public class Account {
 	@Column(name = "account_id")
 	private Long id;
 
-	@Column(name = "accountNumber", nullable = false, unique = true)
+	@Column(name = "accountNum", nullable = false, unique = true)
 	private Long accountNum;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/org/c4marathon/assignment/account/dto/SendDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/SendDto.java
@@ -8,7 +8,7 @@ public record SendDto(
         @NotNull(message = "계좌 번호는 필수 입력 항목입니다.")
         Long accountNum,
         @Min(value = 0, message = "송금액은 0원 이상이어야 합니다.")
-        int sendMoney,
+        int sendToMoney,
         @NotNull(message = "계좌 비밀번호는 필수 입력 항목입니다.")
         int accountPw
 ) {

--- a/src/main/java/org/c4marathon/assignment/account/dto/SendDto.java
+++ b/src/main/java/org/c4marathon/assignment/account/dto/SendDto.java
@@ -2,13 +2,14 @@ package org.c4marathon.assignment.account.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record SendDto(
-        @NotBlank(message = "계좌 번호는 필수 입력 항목입니다.")
+        @NotNull(message = "계좌 번호는 필수 입력 항목입니다.")
         Long accountNum,
         @Min(value = 0, message = "송금액은 0원 이상이어야 합니다.")
         int sendMoney,
-        @NotBlank(message = "계좌 비밀번호는 필수 입력 항목입니다.")
+        @NotNull(message = "계좌 비밀번호는 필수 입력 항목입니다.")
         int accountPw
 ) {
 }

--- a/src/main/java/org/c4marathon/assignment/account/exception/NotFountAccountException.java
+++ b/src/main/java/org/c4marathon/assignment/account/exception/NotFountAccountException.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotFountAccountException implements ErrorCode {
-	NOT_FOUNT_ACCOUNT("계좌번호와 일치하는 계좌를 찾을 수 없습니다", "ACCOUNT_003"),
+	NOT_FOUND_ACCOUNT("계좌번호와 일치하는 계좌를 찾을 수 없습니다", "ACCOUNT_003"),
 	NOT_MATCH_ACCOUNT("비밀번호와 일치하는 계좌를 찾을 수 없습니다", "ACCOUNT_004");
 
 	private final String message;

--- a/src/main/java/org/c4marathon/assignment/account/exception/NotFountAccountException.java
+++ b/src/main/java/org/c4marathon/assignment/account/exception/NotFountAccountException.java
@@ -8,9 +8,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotFountAccountException implements ErrorCode {
-	NOT_FOUNT_ACCOUNT("계좌번호와 일치하는 계좌를 찾을 수 없습니다", "ACCOUNT_003"),
+	NOT_FOUND_ACCOUNT("계좌번호와 일치하는 계좌를 찾을 수 없습니다", "ACCOUNT_003"),
 	NOT_MATCH_ACCOUNT("비밀번호와 일치하는 계좌를 찾을 수 없습니다", "ACCOUNT_004"),
-	NOT_FOUNT_MAIN_ACCOUNT("아이디에 일치하는 메인 계좌를 찾을 수 없습니다", "ACCOUNT_005");
+	NOT_FOUND_MAIN_ACCOUNT("아이디에 일치하는 메인 계좌를 찾을 수 없습니다", "ACCOUNT_005"),
+	NOT_FOUND_OTHER_MAIN_ACCOUNT("계좌번호와 일치하는 메인 계좌가 없습니다", "ACCOUNT_006");
 
 	private final String message;
 	private final String code;

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -16,4 +16,7 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
 	@Query("SELECT a FROM Account a WHERE a.user.userId = :userId AND a.type = :type")
 	Optional<Account> findByMainAccount(@Param("userId") String userId, @Param("type") AccountType type);
+
+	@Query("SELECT a FROM Account a WHERE a.accountNum = :accountNum AND a.type = :type")
+	Optional<Account> findByOtherMainAccount(@Param("accountNum") Long accountNum, @Param("type") AccountType type);
 }

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -5,18 +5,25 @@ import java.util.Optional;
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.AccountType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
 	@Query("SELECT a FROM Account a WHERE a.accountNum = :accountNum")
 	Optional<Account> findByAccount(Long accountNum);
 
+	@Query("SELECT a FROM Account a WHERE a.accountNum = :accountNum AND a.type = :type")
+	Optional<Account> findByAccountNumber(@Param("accountNum") Long accountNum, @Param("type") AccountType type);
+
 	@Query("SELECT a FROM Account a WHERE a.user.userId = :userId AND a.type = :type")
 	Optional<Account> findByMainAccount(@Param("userId") String userId, @Param("type") AccountType type);
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT a FROM Account a WHERE a.accountNum = :accountNum AND a.type = :type")
 	Optional<Account> findByOtherMainAccount(@Param("accountNum") Long accountNum, @Param("type") AccountType type);
 }

--- a/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
+++ b/src/main/java/org/c4marathon/assignment/account/repository/AccountRepository.java
@@ -16,6 +16,4 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 	@Query("SELECT a FROM Account a WHERE a.accountPw = :accountPw")
 	Optional findByMyAccount(int accountPw);
 
-	Optional<Account> findByUser_IdAndType(Long userId, AccountType type);
-
 }

--- a/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
+++ b/src/main/java/org/c4marathon/assignment/account/service/AccountService.java
@@ -14,6 +14,7 @@ import org.c4marathon.assignment.account.exception.NotFountAccountException;
 import org.c4marathon.assignment.account.repository.AccountRepository;
 import org.c4marathon.assignment.common.exception.BaseException;
 import org.c4marathon.assignment.user.domain.User;
+import org.c4marathon.assignment.user.exception.LoginException;
 import org.c4marathon.assignment.user.repository.UserRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ public class AccountService {
 	private final UserRepository userRepository;
 	Long randomAccountNum = new Random().nextLong();
 
+	// 정각마다 일일한도 초기화 서비스
 	@Scheduled(cron = "0 0 0 * * *")
 	@Transactional(isolation = Isolation.SERIALIZABLE)
 	public void resetLimitAccount() {
@@ -39,26 +41,22 @@ public class AccountService {
 		}
 	}
 
+	// 메인 계좌 충전 서비스
 	@Transactional(isolation = Isolation.REPEATABLE_READ)
 	public boolean chargeMainAccount(ChargeDto chargeDto) {
-
 		Optional<Account> optionalAccount = accountRepository.findByAccount(chargeDto.accountNum());
-
-		if (optionalAccount.isPresent()) {
-			Account account = optionalAccount.get();
-
-			account.setAmount(chargeDto.chargeMoney());
-			return true;
-		}
-
-		return false;
+		optionalAccount.orElseThrow(() -> new BaseException(NotFountAccountException.NOT_FOUNT_ACCOUNT));
+		Account account = optionalAccount.get();
+		account.setAmount(chargeDto.chargeMoney());
+		return true;
 	}
 
+	// 적금 계좌 생성 서비스
 	@Transactional(isolation = Isolation.REPEATABLE_READ)
 	public boolean craeteSavingAccount(String userId, SavingAccountPwDto savingAccountPwDto) {
 		Optional<User> userOptional = userRepository.findByUserId(userId);
+		userOptional.orElseThrow(()-> new BaseException(LoginException.NOT_FOUND_USER));
 
-		if (userOptional.isPresent()) {
 			User user = userOptional.get();
 			Account account = Account.builder()
 				.accountNum(randomAccountNum)
@@ -70,21 +68,18 @@ public class AccountService {
 
 			accountRepository.save(account);
 			return true;
-		} else {
-			return false;
-		}
 	}
 
-	@Transactional(isolation = Isolation.SERIALIZABLE)
-	public boolean sendSavingAccount(Long userId, SendDto sendDto) {
+	// 메인 계좌 -> 적금 계좌로 송금 서비스
+	@Transactional(isolation = Isolation.REPEATABLE_READ)
+	public boolean sendSavingAccount(SendDto sendDto) {
 		Optional<Account> optionalAccount = accountRepository.findByAccount(sendDto.accountNum());
 		Optional<Account> optionalMyAccount = accountRepository.findByMyAccount(sendDto.accountPw());
-		Optional<Account> mainAccount = accountRepository.findByUser_IdAndType(userId, AccountType.MAIN_ACCOUNT);
 
 		optionalAccount.orElseThrow(() -> new BaseException(NotFountAccountException.NOT_FOUNT_ACCOUNT));
 		optionalMyAccount.orElseThrow(() -> new BaseException(NotFountAccountException.NOT_MATCH_ACCOUNT));
 
-		Account main = mainAccount.get();
+		Account main = optionalMyAccount.get();
 		Account saving = optionalAccount.get();
 		int checkMoney = main.getAmount() - sendDto.sendMoney();
 
@@ -97,5 +92,32 @@ public class AccountService {
 		} else {
 			throw new BaseException(MainAccountException.SHORT_MONEY);
 		}
+	}
+
+	// 메인 계좌 -> 다른 유저의 메인 계좌로 송금 서비스
+	@Transactional(isolation = Isolation.REPEATABLE_READ)
+	public boolean sendOtherAccount(SendDto sendDto) {
+		Optional<Account> optionalMyAccount = accountRepository.findByMyAccount(sendDto.accountPw());
+		Optional<Account> optionalAccount = accountRepository.findByAccount(sendDto.accountNum());
+
+		optionalMyAccount.orElseThrow(() -> new BaseException(NotFountAccountException.NOT_MATCH_ACCOUNT));
+		optionalAccount.orElseThrow(() -> new BaseException(NotFountAccountException.NOT_FOUNT_ACCOUNT));
+
+		Account mainAccount = optionalMyAccount.get();
+		Account otherAccount = optionalAccount.get();
+		int checkMoney = mainAccount.getAmount() - sendDto.sendMoney();
+		int lackingMoney = sendDto.sendMoney() - mainAccount.getAmount();
+
+		if (checkMoney > 0) {
+			otherAccount.increaseAmount(sendDto.sendMoney());
+			mainAccount.reduceAmount(sendDto.sendMoney());
+			accountRepository.save(mainAccount);
+			accountRepository.save(otherAccount);
+			return true;
+		}else {
+			int chargeMoney = (int)(Math.round(lackingMoney / 10000.0) * 10000);
+			chargeMainAccount(new ChargeDto(mainAccount.getAccountNum(), chargeMoney));
+		}
+		return false;
 	}
 }

--- a/src/test/java/org/c4marathon/assignment/account/AccountTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/AccountTest.java
@@ -181,23 +181,19 @@ public class AccountTest {
 		// 회원가입
 		User user = new User("user123", "password", "홍길동", 1234);
 
-		given(userRepository.findByUserId(user.getUserId())).willReturn(Optional.of(user));
-
 		// 메인 계좌 생성
 		Account mainAccount = new Account(12345678L, AccountType.MAIN_ACCOUNT, 10000, 1234, 3000000, user);
-
 		given(accountRepository.findByMainAccount(user.getUserId(), AccountType.MAIN_ACCOUNT)).willReturn(
 			Optional.of(mainAccount));
 
 		// 적금 계좌 생성
 		Account savingAccount = new Account(11111111L, AccountType.SAVING_ACCOUNT, 0, 1111, 3000000, user);
-
 		given(accountRepository.findByAccount(savingAccount.getAccountNum())).willReturn(Optional.of(savingAccount));
 
 		SendDto sendDto = new SendDto(11111111L, 5000, 1234);
 
 		// when
-		mockMvc.perform(post("/account/send/{userId}", user.getUserId())
+		mockMvc.perform(post("/account/send/saving/{userId}", user.getUserId())
 				.content(toJson(sendDto))
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk());
@@ -214,23 +210,19 @@ public class AccountTest {
 		// 회원가입
 		User user = new User("user123", "password", "홍길동", 1234);
 
-		given(userRepository.findByUserId(user.getUserId())).willReturn(Optional.of(user));
-
 		// 메인 계좌 생성
 		Account mainAccount = new Account(12345678L, AccountType.MAIN_ACCOUNT, 10000, 1234, 3000000, user);
-
 		given(accountRepository.findByMainAccount(user.getUserId(), AccountType.MAIN_ACCOUNT)).willReturn(
 			Optional.of(mainAccount));
 
 		// 적금 계좌 생성
 		Account savingAccount = new Account(11111111L, AccountType.SAVING_ACCOUNT, 0, 1111, 3000000, user);
-
 		given(accountRepository.findByAccount(savingAccount.getAccountNum())).willReturn(Optional.of(savingAccount));
 
 		SendDto sendDto = new SendDto(11111111L, 15000, 1234);
 
 		// when, then
-		mockMvc.perform(post("/account/send/{userId}", user.getUserId())
+		mockMvc.perform(post("/account/send/saving/{userId}", user.getUserId())
 				.content(toJson(sendDto))
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk());
@@ -244,25 +236,54 @@ public class AccountTest {
 		// 회원가입
 		User user = new User("user123", "password", "홍길동", 1234);
 
-		given(userRepository.findByUserId(user.getUserId())).willReturn(Optional.of(user));
-
 		// 메인 계좌 생성
 		Account mainAccount = new Account(12345678L, AccountType.MAIN_ACCOUNT, 10000, 1234, 3000000, user);
-
 		given(accountRepository.findByMainAccount(user.getUserId(), AccountType.MAIN_ACCOUNT)).willReturn(
 			Optional.of(mainAccount));
 
 		// 적금 계좌 생성
 		Account savingAccount = new Account(11111111L, AccountType.SAVING_ACCOUNT, 0, 1111, 3000000, user);
-
 		given(accountRepository.findByAccount(savingAccount.getAccountNum())).willReturn(Optional.of(savingAccount));
 
 		SendDto sendDto = new SendDto(11111111L, 5000, 1111);
 
 		// when, then
-		mockMvc.perform(post("/account/send/{userId}", user.getUserId())
+		mockMvc.perform(post("/account/send/saving/{userId}", user.getUserId())
 				.content(toJson(sendDto))
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk());
+	}
+
+	@DisplayName("[다른 사람 메인 계좌 송금 테스트]")
+	@Test
+	void sendToOtherTest() throws Exception {
+
+		// given
+		// 유저 1
+		User user1 = new User("user123", "password", "홍길동", 1234);
+		// 유저 2
+		User user2 = new User("user111", "password", "고길동", 4321);
+
+		// 메인 계좌 생성
+		Account mainAccount1 = new Account(12345678L, AccountType.MAIN_ACCOUNT, 10000, 1234, 3000000, user1);
+		given(accountRepository.findByMainAccount(user1.getUserId(), AccountType.MAIN_ACCOUNT)).willReturn(
+			Optional.of(mainAccount1));
+
+		// 다른 사람 메인 계좌 생성
+		Account mainAccount2 = new Account(1234567890L, AccountType.MAIN_ACCOUNT, 10000, 4321, 3000000, user2);
+		given(accountRepository.findByOtherMainAccount(mainAccount2.getAccountNum(), AccountType.MAIN_ACCOUNT)).willReturn(
+			Optional.of(mainAccount2));
+
+		SendDto sendDto = new SendDto(mainAccount2.getAccountNum(), 5000, 1234);
+
+		// when
+		mockMvc.perform(post("/account/send/other/{userId}", user1.getUserId())
+				.content(toJson(sendDto))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk());
+
+		// then
+		assertEquals(5000, mainAccount1.getAmount());
+		assertEquals(15000, mainAccount2.getAmount());
 	}
 }

--- a/src/test/java/org/c4marathon/assignment/account/AccountTest.java
+++ b/src/test/java/org/c4marathon/assignment/account/AccountTest.java
@@ -5,9 +5,14 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.c4marathon.assignment.account.domain.Account;
 import org.c4marathon.assignment.account.domain.AccountType;
@@ -28,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,6 +51,8 @@ public class AccountTest {
 	@Autowired
 	private AccountService accountService;
 
+	private ExecutorService executorService;
+
 	@Autowired
 	private MockMvc mockMvc;
 
@@ -58,6 +66,7 @@ public class AccountTest {
 	@BeforeEach
 	void start() {
 		accountRepository.deleteAll();
+		executorService = Executors.newFixedThreadPool(10);
 	}
 
 	@AfterEach
@@ -271,7 +280,8 @@ public class AccountTest {
 
 		// 다른 사람 메인 계좌 생성
 		Account mainAccount2 = new Account(1234567890L, AccountType.MAIN_ACCOUNT, 10000, 4321, 3000000, user2);
-		given(accountRepository.findByOtherMainAccount(mainAccount2.getAccountNum(), AccountType.MAIN_ACCOUNT)).willReturn(
+		given(accountRepository.findByOtherMainAccount(mainAccount2.getAccountNum(),
+			AccountType.MAIN_ACCOUNT)).willReturn(
 			Optional.of(mainAccount2));
 
 		SendDto sendDto = new SendDto(mainAccount2.getAccountNum(), 5000, 1234);
@@ -285,5 +295,95 @@ public class AccountTest {
 		// then
 		assertEquals(5000, mainAccount1.getAmount());
 		assertEquals(15000, mainAccount2.getAmount());
+	}
+
+	@DisplayName("[다른 사람 메인 계좌 송금 테스트 ( RepeatableRead와 비관적 락을 사용 ) ]")
+	@Test
+	@Transactional
+	public void testSendOtherAccountWithRepeatableRead() throws InterruptedException {
+		// given
+		List<Callable<Void>> tasks = new ArrayList<>();
+		// 유저 1
+		User user1 = new User("user123", "password", "홍길동", 1234);
+		// 유저 2
+		User user2 = new User("user111", "password", "고길동", 4321);
+
+		// 메인 계좌 생성
+		Account mainAccount1 = new Account(12345678L, AccountType.MAIN_ACCOUNT, 10000, 1234, 3000000, user1);
+		given(accountRepository.findByMainAccount(user1.getUserId(), AccountType.MAIN_ACCOUNT)).willReturn(
+			Optional.of(mainAccount1));
+
+		// 다른 사람 메인 계좌 생성
+		Account mainAccount2 = new Account(1234567890L, AccountType.MAIN_ACCOUNT, 10000, 4321, 3000000, user2);
+		given(accountRepository.findByOtherMainAccount(mainAccount2.getAccountNum(),
+			AccountType.MAIN_ACCOUNT)).willReturn(
+			Optional.of(mainAccount2));
+
+		// 100명이 동시에 송금 시도 (각각 100원씩 송금)
+		for (int i = 0; i < 100; i++) {
+			tasks.add(() -> {
+				SendDto sendDto = new SendDto(1234567890L, 100, 4321); // 1234567890L 계좌로 100원 송금
+				accountService.sendOtherAccount(user1.getUserId(), sendDto);
+				return null;
+			});
+		}
+
+		long startTime = System.currentTimeMillis();
+		List<Future<Void>> futures = executorService.invokeAll(tasks); // 100개의 송금 작업 실행
+		long endTime = System.currentTimeMillis();
+
+		Account senderAccount = accountRepository.findByMainAccount(user1.getUserId(), AccountType.MAIN_ACCOUNT)
+			.orElseThrow();
+		Account receiverAccount = accountRepository.findByOtherMainAccount(mainAccount2.getAccountNum(),
+			AccountType.MAIN_ACCOUNT).orElseThrow();
+
+		System.out.println("REPEATABLE READ - 송신 계좌 잔액: " + senderAccount.getAmount());
+		System.out.println("REPEATABLE READ - 수신 계좌 잔액: " + receiverAccount.getAmount());
+		System.out.println("REPEATABLE READ - 실행 시간: " + (endTime - startTime) + "ms");
+	}
+
+	@DisplayName("[다른 사람 메인 계좌 송금 테스트 ( Serializable만 사용 ) ]")
+	@Test
+	@Transactional
+	public void testSendOtherAccountWithSerializable() throws InterruptedException {
+		// given
+		List<Callable<Void>> tasks = new ArrayList<>();
+		// 유저 1
+		User user1 = new User("user123", "password", "홍길동", 1234);
+		// 유저 2
+		User user2 = new User("user111", "password", "고길동", 4321);
+
+		// 메인 계좌 생성
+		Account mainAccount1 = new Account(12345678L, AccountType.MAIN_ACCOUNT, 10000, 1234, 3000000, user1);
+		given(accountRepository.findByMainAccount(user1.getUserId(), AccountType.MAIN_ACCOUNT)).willReturn(
+			Optional.of(mainAccount1));
+
+		// 다른 사람 메인 계좌 생성
+		Account mainAccount2 = new Account(1234567890L, AccountType.MAIN_ACCOUNT, 10000, 4321, 3000000, user2);
+		given(accountRepository.findByAccountNumber(mainAccount2.getAccountNum(),
+			AccountType.MAIN_ACCOUNT)).willReturn(
+			Optional.of(mainAccount2));
+
+		// 100명이 동시에 송금 시도 (각각 100원씩 송금)
+		for (int i = 0; i < 100; i++) {
+			tasks.add(() -> {
+				SendDto sendDto = new SendDto(1234567890L, 100, 4321); // 1234567890L 계좌로 100원 송금
+				accountService.sendOtherAccountSERIALIZABLE(user1.getUserId(), sendDto);
+				return null;
+			});
+		}
+
+		long startTime = System.currentTimeMillis();
+		List<Future<Void>> futures = executorService.invokeAll(tasks); // 100개의 송금 작업 실행
+		long endTime = System.currentTimeMillis();
+
+		Account senderAccount = accountRepository.findByMainAccount(user1.getUserId(), AccountType.MAIN_ACCOUNT)
+			.orElseThrow();
+		Account receiverAccount = accountRepository.findByAccountNumber(mainAccount2.getAccountNum(),
+			AccountType.MAIN_ACCOUNT).orElseThrow();
+
+		System.out.println("SERIALIZABLE - 송신 계좌 잔액: " + senderAccount.getAmount());
+		System.out.println("SERIALIZABLE - 수신 계좌 잔액: " + receiverAccount.getAmount());
+		System.out.println("SERIALIZABLE - 실행 시간: " + (endTime - startTime) + "ms");
 	}
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a4700012-a120-4787-b213-adc378f97feb)

### 작업 내용

- 다른 사람의 메인 계좌로 돈 송금하는 기능 추가
- 만일 송금시 잔액이 부족하다면 10000원 단위로 자동 충전
- 동시성 성능 비교를 위해 SERIALIZABLE 격리성과 REPEATABLE_READ 격리성에 비관적 락을 추가하는 두 가지 성능을 비교

### 성능 비교

두 가지 성능을 놓고 소모되는 시간을 비교해 봤을 때, 다음과 같았습니다.
![image](https://github.com/user-attachments/assets/86ddcb45-640f-44c7-9ceb-248d7172aa49)
![image](https://github.com/user-attachments/assets/93911764-9409-4667-aa05-c52f93ed7b5d)

### 아쉬운 점

- 뭔가 SERIALIZABLE 격리성과 REPEATABLE_READ 격리성에 비관적 락을 추가하는 두 가지 성능 이외에도 좋은 방법이 많이 있을 거 같은데 더 고민하지 못한 점
- 테스트 코드의 상황이 좀 더 다양한 상황이 발생하지 않을까? 하는 점
- 트랜잭션을 짧게 가져가라고 했는데 어떻게 해야 더 짧게 가져갈 지 고민해봤지만 해당 부분에 대해 정확한 답이 나오지 않은 점